### PR TITLE
Rename ratings to votes and add rating to review

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -16,6 +16,6 @@ class ReviewsController < ApplicationController
   private
 
   def review_params
-    params.require(:review).permit(:title, :body)
+    params.require(:review).permit(:rating, :title, :body)
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,11 +1,13 @@
 class Review < ApplicationRecord
   belongs_to :user
   belongs_to :book
-  has_many :ratings, dependent: :destroy
+  has_many :votes, dependent: :destroy
 
-  validates_presence_of :title, :body, :user_id, :book_id
+  validates_presence_of :rating, :user_id, :book_id
   validates :title, length: { maximum: 50 }
   validates :body, length: { maximum: 1000 }
+  validates :rating, numericality: { only_integer: true, greater_than: 0,
+    less_than_or_equal_to: 10 }
   validates :user_id, numericality: { only_integer: true }
   validates :book_id, numericality: { only_integer: true }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
 
   has_many :books
   has_many :reviews
-  has_many :ratings
+  has_many :votes
 
   validates_presence_of :first_name, :last_name
 end

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,4 +1,4 @@
-class Rating < ApplicationRecord
+class Vote < ApplicationRecord
   belongs_to :review
   belongs_to :user
 
@@ -6,5 +6,5 @@ class Rating < ApplicationRecord
   validates :user_id, numericality: { only_integer: true }
   validates :review_id, numericality: { only_integer: true }
   validates :user_id, uniqueness: { scope: :review_id,
-    message: "Each user can rate a review only once" }
+    message: "Each user can vote on a review only once" }
 end

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -34,6 +34,12 @@
         <% end %>
 
         <div class="field">
+          <%= f.label :rating %><br />
+          <%= f.select(:rating, (1..10).to_a, { prompt: 'Select a rating'}) %>
+          <p>(1 is the worst and 10 is the best)</p>
+        </div>
+
+        <div class="field">
           <%= f.label :title %><br />
           <%= f.text_field :title, value: @review.title %>
         </div>
@@ -58,7 +64,8 @@
     <% @reviews.each do |review| %>
       <div class="review">
         <li>
-          <h5><%= review.title %></h5>
+          <h3><%= review.rating %> out of 10</h3>
+          <h4><%= review.title %></h4>
           <p><%= review.body %></p>
         </li>
       </div>

--- a/db/migrate/20180927165917_rename_rating_to_vote.rb
+++ b/db/migrate/20180927165917_rename_rating_to_vote.rb
@@ -1,0 +1,5 @@
+class RenameRatingToVote < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :ratings, :votes
+  end
+end

--- a/db/migrate/20180927170647_add_rating_to_review.rb
+++ b/db/migrate/20180927170647_add_rating_to_review.rb
@@ -1,0 +1,5 @@
+class AddRatingToReview < ActiveRecord::Migration[5.2]
+  def change
+    add_column :reviews, :rating, :integer, null: false
+  end
+end

--- a/db/migrate/20180927172443_modify_review_title_and_body.rb
+++ b/db/migrate/20180927172443_modify_review_title_and_body.rb
@@ -1,0 +1,15 @@
+class ModifyReviewTitleAndBody < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :reviews, :title, :string, null: false
+    remove_column :reviews, :body, :string, null: false
+    add_column :reviews, :title, :string
+    add_column :reviews, :body, :string
+  end
+
+  def down
+    remove_column :reviews, :title, :string
+    remove_column :reviews, :body, :string
+    add_column :reviews, :title, :string, null: false
+    add_column :reviews, :body, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_25_172800) do
+ActiveRecord::Schema.define(version: 2018_09_27_172443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,22 +27,14 @@ ActiveRecord::Schema.define(version: 2018_09_25_172800) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "ratings", force: :cascade do |t|
-    t.boolean "upvote", null: false
-    t.integer "user_id", null: false
-    t.integer "review_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id", "review_id"], name: "index_ratings_on_user_id_and_review_id", unique: true
-  end
-
   create_table "reviews", force: :cascade do |t|
-    t.string "title", null: false
-    t.string "body", null: false
     t.integer "user_id", null: false
     t.integer "book_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "rating", null: false
+    t.string "title"
+    t.string "body"
   end
 
   create_table "users", force: :cascade do |t|
@@ -59,6 +51,15 @@ ActiveRecord::Schema.define(version: 2018_09_25_172800) do
     t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "votes", force: :cascade do |t|
+    t.boolean "upvote", null: false
+    t.integer "user_id", null: false
+    t.integer "review_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "review_id"], name: "index_votes_on_user_id_and_review_id", unique: true
   end
 
 end

--- a/spec/factories/reviews.rb
+++ b/spec/factories/reviews.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :review do
+    rating {10}
     title {"Best Book Ever!"}
     body {"I could not put it down! Already halfway through the second book in \
       the series and cannot wait for the third! Patrick Rothfuss is a literary \

--- a/spec/features/create_review_spec.rb
+++ b/spec/features/create_review_spec.rb
@@ -47,16 +47,17 @@ feature 'user tries to add a review' do
     visit books_path
     click_on 'The Name of the Wind'
 
+    select 10, from: 'Rating'
     fill_in 'Title', with: 'Best Book Ever!'
     fill_in 'Body', with: "I could not put it down! Already halfway through \
       the second book in the series and cannot wait for the third! Patrick \
       Rothfuss is a literary genius."
     click_on 'Submit'
 
+    expect(page).to have_content('Your review was posted successfully')
+    expect(page).to have_content('Patrick Rothfuss', count: 2)
     expect(find_field('Title').value).to eq(nil)
     expect(find_field('Body').value).to eq('')
-    expect(page).to have_content('Patrick Rothfuss', count: 2)
-    expect(page).to have_content('Your review was posted successfully')
   end
 
   scenario 'provides invalid information' do

--- a/spec/features/view_reviews_spec.rb
+++ b/spec/features/view_reviews_spec.rb
@@ -17,6 +17,7 @@ feature 'user tries to view a list of reviews' do
     visit books_path
     click_on 'The Name of the Wind'
 
+    expect(page).to have_content('10 out of 10')
     expect(page).to have_content('Patrick Rothfuss', count: 2)
     expect(page).not_to have_content("The Wise Man's Fear")
   end


### PR DESCRIPTION
So that upvoting or downvoting a review made sense, rename ratings table to votes table. Add a rating column to the review table so that books can be rated 1 - 10. Updates to the factories, models, and tests for consistency.